### PR TITLE
p2p: Refactor, move checksum verification into net, without changing behavior

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -566,6 +566,16 @@ void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)
 }
 #undef X
 
+/**
+ * Receive bytes from the buffer and deserialize them into messages.
+ * 
+ * @param[in]   pch         Socket buffer
+ * @param[in]   nBytes      Size of the socket buffer
+ * @param[out]  complete    Set True if a message has been deserialized and is 
+ *                          ready to be processed
+ * @return  True if the peer should stay connected, 
+ *          False if the peer should be disconnected from.
+ */
 bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete)
 {
     complete = false;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -583,7 +583,10 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete
 
         if (m_deserializer->Complete()) {
             // decompose a transport agnostic CNetMessage from the deserializer
-            CNetMessage msg = m_deserializer->GetMessage(Params().MessageStart(), nTimeMicros);
+            boost::optional<CNetMessage> result = m_deserializer->GetMessage(Params().MessageStart(), nTimeMicros);
+            if(!result)
+                continue;
+            CNetMessage msg = *result;
 
             //store received bytes per message command
             //to prevent a memory DOS, only allow valid commands
@@ -686,7 +689,7 @@ const uint256& V1TransportDeserializer::GetMessageHash() const
     return data_hash;
 }
 
-CNetMessage V1TransportDeserializer::GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) {
+boost::optional<CNetMessage> V1TransportDeserializer::GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) {
     // decompose a single CNetMessage from the TransportDeserializer
     CNetMessage msg(std::move(vRecv));
 
@@ -703,12 +706,14 @@ CNetMessage V1TransportDeserializer::GetMessage(const CMessageHeader::MessageSta
     // We just received a message off the wire, harvest entropy from the time (and the message checksum)
     RandAddEvent(ReadLE32(hash.begin()));
 
-    msg.m_valid_checksum = (memcmp(hash.begin(), hdr.pchChecksum, CMessageHeader::CHECKSUM_SIZE) == 0);
-    if (!msg.m_valid_checksum) {
+    bool valid_checksum = (memcmp(hash.begin(), hdr.pchChecksum, CMessageHeader::CHECKSUM_SIZE) == 0);
+    if (!valid_checksum) {
         LogPrint(BCLog::NET, "CHECKSUM ERROR (%s, %u bytes), expected %s was %s\n",
                  SanitizeString(msg.m_command), msg.m_message_size,
                  HexStr(hash.begin(), hash.begin()+CMessageHeader::CHECKSUM_SIZE),
                  HexStr(hdr.pchChecksum, hdr.pchChecksum+CMessageHeader::CHECKSUM_SIZE));
+        Reset();
+        return boost::none;
     }
 
     // store receive time

--- a/src/net.h
+++ b/src/net.h
@@ -616,7 +616,6 @@ public:
     int64_t m_time = 0;                  // time (in microseconds) of message receipt.
     bool m_valid_netmagic = false;
     bool m_valid_header = false;
-    bool m_valid_checksum = false;
     uint32_t m_message_size = 0;         // size of the payload
     uint32_t m_raw_message_size = 0;     // used wire size of the message (including header/checksum)
     std::string m_command;
@@ -642,7 +641,7 @@ public:
     // read and deserialize data
     virtual int Read(const char *data, unsigned int bytes) = 0;
     // decomposes a message from the context
-    virtual CNetMessage GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) = 0;
+    virtual boost::optional<CNetMessage> GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) = 0;
     virtual ~TransportDeserializer() {}
 };
 
@@ -695,7 +694,7 @@ public:
         if (ret < 0) Reset();
         return ret;
     }
-    CNetMessage GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) override;
+    boost::optional<CNetMessage> GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) override;
 };
 
 /** The TransportSerializer prepares messages for the network transport

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3602,20 +3602,11 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     // Message size
     unsigned int nMessageSize = msg.m_message_size;
 
-    // Checksum
-    CDataStream& vRecv = msg.m_recv;
-    if (!msg.m_valid_checksum)
-    {
-        LogPrint(BCLog::NET, "%s(%s, %u bytes): CHECKSUM ERROR peer=%d\n", __func__,
-           SanitizeString(msg_type), nMessageSize, pfrom->GetId());
-        return fMoreWork;
-    }
-
     // Process message
     bool fRet = false;
     try
     {
-        fRet = ProcessMessage(pfrom, msg_type, vRecv, msg.m_time, chainparams, m_chainman, m_mempool, connman, m_banman, interruptMsgProc);
+        fRet = ProcessMessage(pfrom, msg_type, msg.m_recv, msg.m_time, chainparams, m_chainman, m_mempool, connman, m_banman, interruptMsgProc);
         if (interruptMsgProc)
             return false;
         if (!pfrom->vRecvGetData.empty())


### PR DESCRIPTION
This is an alternative approach to #15206 , without changing the disconnect behavior. I agree with this [comment](https://github.com/bitcoin/bitcoin/pull/15206#discussion_r428042604), and this PR is the other alternative, keeping the changes in net.cpp.