### PR TITLE
p2p: Refactor, move all header verification into net, without changing behavior

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -572,6 +572,16 @@ void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)
 }
 #undef X
 
+/**
+ * Receive bytes from the buffer and deserialize them into messages.
+ *
+ * @param[in]   pch         Socket buffer
+ * @param[in]   nBytes      Size of the socket buffer
+ * @param[out]  complete    Set True if a message has been deserialized and is
+ *                          ready to be processed
+ * @return  True if the peer should stay connected,
+ *          False if the peer should be disconnected from.
+ */
 bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete)
 {
     complete = false;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -666,11 +666,19 @@ int V1TransportDeserializer::readHeader(const char *pch, unsigned int nBytes)
         hdrbuf >> hdr;
     }
     catch (const std::exception&) {
+        LogPrint(BCLog::NET, "HEADER ERROR - UNABLE TO DESERIALIZE\n");
+        return -1;
+    }
+
+    // Check start string, network magic
+    if (memcmp(hdr.pchMessageStart, chain_params.MessageStart(), CMessageHeader::MESSAGE_START_SIZE) != 0) {
+        LogPrint(BCLog::NET, "HEADER ERROR - MESSAGESTART (%s, %u bytes), got %s\n", hdr.GetCommand(), hdr.nMessageSize + CMessageHeader::HEADER_SIZE, hdr.GetMessageStart());
         return -1;
     }
 
     // reject messages larger than MAX_SIZE or MAX_PROTOCOL_MESSAGE_LENGTH
     if (hdr.nMessageSize > MAX_SIZE || hdr.nMessageSize > MAX_PROTOCOL_MESSAGE_LENGTH) {
+        LogPrint(BCLog::NET, "HEADER ERROR - SIZE (%s, %u bytes)\n", hdr.GetCommand(), hdr.nMessageSize + CMessageHeader::HEADER_SIZE);
         return -1;
     }
 
@@ -709,9 +717,11 @@ Optional<CNetMessage> V1TransportDeserializer::GetMessage(int64_t time) {
     // decompose a single CNetMessage from the TransportDeserializer
     CNetMessage msg(std::move(vRecv));
 
-    // store state about valid header, netmagic and checksum
-    msg.m_valid_header = hdr.IsValid(Params().MessageStart());
-    msg.m_valid_netmagic = (memcmp(hdr.pchMessageStart, Params().MessageStart(), CMessageHeader::MESSAGE_START_SIZE) == 0);
+    // Check the header
+    if (!hdr.IsValid()){
+        Reset();
+        return nullopt;
+    }
 
     // store command string, payload size
     msg.m_command = hdr.GetCommand();
@@ -723,6 +733,7 @@ Optional<CNetMessage> V1TransportDeserializer::GetMessage(int64_t time) {
     // We just received a message off the wire, harvest entropy from the time (and the message checksum)
     RandAddEvent(ReadLE32(hash.begin()));
 
+    // Check checksum
     bool valid_checksum = (memcmp(hash.begin(), hdr.pchChecksum, CMessageHeader::CHECKSUM_SIZE) == 0);
     if (!valid_checksum) {
         LogPrint(BCLog::NET, "CHECKSUM ERROR (%s, %u bytes), expected %s was %s\n",

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -599,7 +599,7 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete
 
         if (m_deserializer->Complete()) {
             // decompose a transport agnostic CNetMessage from the deserializer
-            Optional<CNetMessage> result = m_deserializer->GetMessage(Params().MessageStart(), nTimeMicros);
+            Optional<CNetMessage> result = m_deserializer->GetMessage(nTimeMicros);
             if(!result)
                 continue;
             CNetMessage msg = *result;
@@ -705,19 +705,20 @@ const uint256& V1TransportDeserializer::GetMessageHash() const
     return data_hash;
 }
 
-Optional<CNetMessage> V1TransportDeserializer::GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) {
+Optional<CNetMessage> V1TransportDeserializer::GetMessage(int64_t time) {
     // decompose a single CNetMessage from the TransportDeserializer
     CNetMessage msg(std::move(vRecv));
 
     // store state about valid header, netmagic and checksum
-    msg.m_valid_header = hdr.IsValid(message_start);
-    msg.m_valid_netmagic = (memcmp(hdr.pchMessageStart, message_start, CMessageHeader::MESSAGE_START_SIZE) == 0);
-    uint256 hash = GetMessageHash();
+    msg.m_valid_header = hdr.IsValid(Params().MessageStart());
+    msg.m_valid_netmagic = (memcmp(hdr.pchMessageStart, Params().MessageStart(), CMessageHeader::MESSAGE_START_SIZE) == 0);
 
     // store command string, payload size
     msg.m_command = hdr.GetCommand();
     msg.m_message_size = hdr.nMessageSize;
     msg.m_raw_message_size = hdr.nMessageSize + CMessageHeader::HEADER_SIZE;
+
+    uint256 hash = GetMessageHash();
 
     // We just received a message off the wire, harvest entropy from the time (and the message checksum)
     RandAddEvent(ReadLE32(hash.begin()));
@@ -2777,7 +2778,7 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
         LogPrint(BCLog::NET, "Added connection peer=%d\n", id);
     }
 
-    m_deserializer = MakeUnique<V1TransportDeserializer>(V1TransportDeserializer(Params().MessageStart(), SER_NETWORK, INIT_PROTO_VERSION));
+    m_deserializer = MakeUnique<V1TransportDeserializer>(V1TransportDeserializer(Params(), SER_NETWORK, INIT_PROTO_VERSION));
     m_serializer = MakeUnique<V1TransportSerializer>(V1TransportSerializer());
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -10,6 +10,7 @@
 #include <addrman.h>
 #include <amount.h>
 #include <bloom.h>
+#include <chainparams.h>
 #include <compat.h>
 #include <crypto/siphash.h>
 #include <hash.h>
@@ -642,13 +643,14 @@ public:
     // read and deserialize data
     virtual int Read(const char *data, unsigned int bytes) = 0;
     // decomposes a message from the context
-    virtual Optional<CNetMessage> GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) = 0;
+    virtual Optional<CNetMessage> GetMessage(int64_t time) = 0;
     virtual ~TransportDeserializer() {}
 };
 
 class V1TransportDeserializer final : public TransportDeserializer
 {
 private:
+    const CChainParams& chain_params;
     mutable CHash256 hasher;
     mutable uint256 data_hash;
     bool in_data;                   // parsing header (false) or data (true)
@@ -675,7 +677,7 @@ private:
 
 public:
 
-    V1TransportDeserializer(const CMessageHeader::MessageStartChars& pchMessageStartIn, int nTypeIn, int nVersionIn) : hdrbuf(nTypeIn, nVersionIn), hdr(pchMessageStartIn), vRecv(nTypeIn, nVersionIn) {
+    V1TransportDeserializer(const CChainParams& chain_params_in, int nTypeIn, int nVersionIn) : chain_params(chain_params_in), hdrbuf(nTypeIn, nVersionIn), hdr(), vRecv(nTypeIn, nVersionIn) {
         Reset();
     }
 
@@ -695,7 +697,7 @@ public:
         if (ret < 0) Reset();
         return ret;
     }
-    Optional<CNetMessage> GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) override;
+    Optional<CNetMessage> GetMessage(int64_t time) override;
 };
 
 /** The TransportSerializer prepares messages for the network transport

--- a/src/net.h
+++ b/src/net.h
@@ -616,8 +616,6 @@ class CNetMessage {
 public:
     CDataStream m_recv;                  // received message data
     int64_t m_time = 0;                  // time (in microseconds) of message receipt.
-    bool m_valid_netmagic = false;
-    bool m_valid_header = false;
     uint32_t m_message_size = 0;         // size of the payload
     uint32_t m_raw_message_size = 0;     // used wire size of the message (including header/checksum)
     std::string m_command;

--- a/src/net.h
+++ b/src/net.h
@@ -16,6 +16,7 @@
 #include <limitedmap.h>
 #include <netaddress.h>
 #include <net_permissions.h>
+#include <optional.h>
 #include <policy/feerate.h>
 #include <protocol.h>
 #include <random.h>
@@ -616,7 +617,6 @@ public:
     int64_t m_time = 0;                  // time (in microseconds) of message receipt.
     bool m_valid_netmagic = false;
     bool m_valid_header = false;
-    bool m_valid_checksum = false;
     uint32_t m_message_size = 0;         // size of the payload
     uint32_t m_raw_message_size = 0;     // used wire size of the message (including header/checksum)
     std::string m_command;
@@ -642,7 +642,7 @@ public:
     // read and deserialize data
     virtual int Read(const char *data, unsigned int bytes) = 0;
     // decomposes a message from the context
-    virtual CNetMessage GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) = 0;
+    virtual Optional<CNetMessage> GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) = 0;
     virtual ~TransportDeserializer() {}
 };
 
@@ -695,7 +695,7 @@ public:
         if (ret < 0) Reset();
         return ret;
     }
-    CNetMessage GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) override;
+    Optional<CNetMessage> GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) override;
 };
 
 /** The TransportSerializer prepares messages for the network transport

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3536,14 +3536,6 @@ bool PeerLogicValidation::CheckIfBanned(CNode* pnode)
 bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc)
 {
     const CChainParams& chainparams = Params();
-    //
-    // Message format
-    //  (4) message start
-    //  (12) command
-    //  (4) size
-    //  (4) checksum
-    //  (x) data
-    //
     bool fMoreWork = false;
 
     if (!pfrom->vRecvGetData.empty())
@@ -3584,19 +3576,6 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     CNetMessage& msg(msgs.front());
 
     msg.SetVersion(pfrom->GetRecvVersion());
-    // Check network magic
-    if (!msg.m_valid_netmagic) {
-        LogPrint(BCLog::NET, "PROCESSMESSAGE: INVALID MESSAGESTART %s peer=%d\n", SanitizeString(msg.m_command), pfrom->GetId());
-        pfrom->fDisconnect = true;
-        return false;
-    }
-
-    // Check header
-    if (!msg.m_valid_header)
-    {
-        LogPrint(BCLog::NET, "PROCESSMESSAGE: ERRORS IN HEADER %s peer=%d\n", SanitizeString(msg.m_command), pfrom->GetId());
-        return fMoreWork;
-    }
     const std::string& msg_type = msg.m_command;
 
     // Message size

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3602,20 +3602,11 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     // Message size
     unsigned int nMessageSize = msg.m_message_size;
 
-    // Checksum
-    CDataStream& vRecv = msg.m_recv;
-    if (!msg.m_valid_checksum)
-    {
-        LogPrint(BCLog::NET, "%s(%s, %u bytes): CHECKSUM ERROR peer=%d\n", __func__,
-           SanitizeString(msg_type), nMessageSize, pfrom->GetId());
-        return fMoreWork;
-    }
-
     // Process message
     bool fRet = false;
     try
     {
-        fRet = ProcessMessage(pfrom, msg_type, vRecv, msg.m_time, chainparams, m_chainman, m_mempool, connman, m_banman, interruptMsgProc);
+        fRet = ProcessMessage(pfrom, msg_type, msg.m_recv, msg.m_time, chainparams, m_chainman, m_mempool, connman, m_banman, interruptMsgProc);
         if (interruptMsgProc)
             return false;
         if (!pfrom->vRecvGetData.empty())

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -82,9 +82,9 @@ const static std::string allNetMessageTypes[] = {
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 
-CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
+CMessageHeader::CMessageHeader()
 {
-    memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
+    memset(pchMessageStart, 0, MESSAGE_START_SIZE);
     memset(pchCommand, 0, sizeof(pchCommand));
     nMessageSize = -1;
     memset(pchChecksum, 0, CHECKSUM_SIZE);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -109,7 +109,12 @@ std::string CMessageHeader::GetCommand() const
     return std::string(pchCommand, pchCommand + strnlen(pchCommand, COMMAND_SIZE));
 }
 
-bool CMessageHeader::IsValid(const MessageStartChars& pchMessageStartIn) const
+std::string CMessageHeader::GetMessageStart() const
+{
+    return std::string(pchMessageStart, pchMessageStart + strnlen(pchMessageStart, MESSAGE_START_SIZE));
+}
+
+bool CMessageHeader::IsValid() const
 {
     // Check start string
     if (memcmp(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE) != 0)

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -116,10 +116,6 @@ std::string CMessageHeader::GetMessageStart() const
 
 bool CMessageHeader::IsValid() const
 {
-    // Check start string
-    if (memcmp(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE) != 0)
-        return false;
-
     // Check the command string for errors
     for (const char* p1 = pchCommand; p1 < pchCommand + COMMAND_SIZE; p1++)
     {
@@ -127,18 +123,15 @@ bool CMessageHeader::IsValid() const
         {
             // Must be all zeros after the first zero
             for (; p1 < pchCommand + COMMAND_SIZE; p1++)
-                if (*p1 != 0)
+                if (*p1 != 0){
+                    LogPrint(BCLog::NET, "HEADER ERROR - COMMAND (%s, %u bytes)\n", GetCommand(), nMessageSize + HEADER_SIZE);
                     return false;
+                }
         }
-        else if (*p1 < ' ' || *p1 > 0x7E)
+        else if (*p1 < ' ' || *p1 > 0x7E){
+            LogPrint(BCLog::NET, "HEADER ERROR - COMMAND (%s, %u bytes)\n", GetCommand(), nMessageSize + HEADER_SIZE);
             return false;
-    }
-
-    // Message size
-    if (nMessageSize > MAX_SIZE)
-    {
-        LogPrintf("CMessageHeader::IsValid(): (%s, %u bytes) nMessageSize > MAX_SIZE\n", GetCommand(), nMessageSize);
-        return false;
+        }
     }
 
     return true;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -44,7 +44,8 @@ public:
     CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn);
 
     std::string GetCommand() const;
-    bool IsValid(const MessageStartChars& messageStart) const;
+    std::string GetMessageStart() const;
+    bool IsValid() const;
 
     SERIALIZE_METHODS(CMessageHeader, obj) { READWRITE(obj.pchMessageStart, obj.pchCommand, obj.nMessageSize, obj.pchChecksum); }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -36,7 +36,7 @@ public:
     static constexpr size_t HEADER_SIZE = MESSAGE_START_SIZE + COMMAND_SIZE + MESSAGE_SIZE_SIZE + CHECKSUM_SIZE;
     typedef unsigned char MessageStartChars[MESSAGE_START_SIZE];
 
-    explicit CMessageHeader(const MessageStartChars& pchMessageStartIn);
+    explicit CMessageHeader();
 
     /** Construct a P2P message header from message-start characters, a command and the size of the message.
      * @note Passing in a `pszCommand` longer than COMMAND_SIZE will result in a run-time assertion error.

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -189,10 +189,9 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         DeserializeFromFuzzingInput(buffer, s);
         AssertEqualAfterSerializeDeserialize(s);
 #elif MESSAGEHEADER_DESERIALIZE
-        const CMessageHeader::MessageStartChars pchMessageStart = {0x00, 0x00, 0x00, 0x00};
-        CMessageHeader mh(pchMessageStart);
+        CMessageHeader mh;
         DeserializeFromFuzzingInput(buffer, mh);
-        (void)mh.IsValid(pchMessageStart);
+        (void)mh.IsValid();
 #elif ADDRESS_DESERIALIZE
         CAddress a;
         DeserializeFromFuzzingInput(buffer, a);

--- a/src/test/fuzz/p2p_transport_deserializer.cpp
+++ b/src/test/fuzz/p2p_transport_deserializer.cpp
@@ -38,12 +38,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             assert(msg.m_raw_message_size <= buffer.size());
             assert(msg.m_raw_message_size == CMessageHeader::HEADER_SIZE + msg.m_message_size);
             assert(msg.m_time == m_time);
-            if (msg.m_valid_header) {
-                assert(msg.m_valid_netmagic);
-            }
-            if (!msg.m_valid_netmagic) {
-                assert(!msg.m_valid_header);
-            }
         }
     }
 }

--- a/src/test/fuzz/p2p_transport_deserializer.cpp
+++ b/src/test/fuzz/p2p_transport_deserializer.cpp
@@ -19,7 +19,7 @@ void initialize()
 
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
-    V1TransportDeserializer deserializer{Params().MessageStart(), SER_NETWORK, INIT_PROTO_VERSION};
+    V1TransportDeserializer deserializer{Params(), SER_NETWORK, INIT_PROTO_VERSION};
     const char* pch = (const char*)buffer.data();
     size_t n_bytes = buffer.size();
     while (n_bytes > 0) {
@@ -31,7 +31,9 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         n_bytes -= handled;
         if (deserializer.Complete()) {
             const int64_t m_time = std::numeric_limits<int64_t>::max();
-            const CNetMessage msg = deserializer.GetMessage(Params().MessageStart(), m_time);
+            auto result = deserializer.GetMessage(m_time);
+            assert(result);
+            const CNetMessage msg = *result;
             assert(msg.m_command.size() <= CMessageHeader::COMMAND_SIZE);
             assert(msg.m_raw_message_size <= buffer.size());
             assert(msg.m_raw_message_size == CMessageHeader::HEADER_SIZE + msg.m_message_size);

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -124,7 +124,8 @@ class InvalidMessagesTest(BitcoinTestFramework):
         #
         # Send messages with an incorrect data size in the header.
         #
-        actual_size = 100
+        # These all fail with a checksum error!  That's not what this test is supposed to test.
+        actual_size = 100   # This is not the actual size of the payload.  Serialization adds (in this case) one byte
         msg = msg_unrecognized(str_data="b" * actual_size)
 
         # TODO: handle larger-than cases. I haven't been able to pin down what behavior to expect.
@@ -134,11 +135,21 @@ class InvalidMessagesTest(BitcoinTestFramework):
             # Unmodified message should submit okay.
             node.p2p.send_and_ping(msg)
 
+            # ==elucidate the confusion below==
+            #print(len(node.p2p.build_message(msg))) # 125
+            # => Payload size = 125 - 24 = 101
+            # If we take 77 bytes, then there are 101 - 77 = 24 left
+            # That's exactly the size of a header
+            # So, bitcoind deserializes the header and rejects it for some other reason
+            # But, if we take 78 bytes, then there are 101 - 78 = 23 left
+            # That's not enough to fill a header, so, what happens?
+
             # A message lying about its data size results in a disconnect when the incorrect
             # data size is less than the actual size.
             #
             # TODO: why does behavior change at 78 bytes?
             #
+            # Answer: See above
             node.p2p.send_raw_message(self._tweak_msg_data_size(msg, wrong_size))
 
             # For some reason unknown to me, we sometimes have to push additional data to the


### PR DESCRIPTION
This is an alternative approach to #15197.  It is a direct extension of #2.